### PR TITLE
Removed unused preg_replace() call to prevent deprecation warning

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -264,7 +264,6 @@ class Query {
 		//if not null does it contain . it could be column so don't parse as string
 		//If not column then use wpdb prepare
 		//if contains $prefix
-		$contain_join = preg_replace( '/^(\s?AND ?|\s?OR ?)|\s$/i', '', $param2 );
 
 		$param2 = is_array( $param2 ) ? ( '("' . implode( '","', $param2 ) . '")' ) : ( $param2 === null ? 'null' : ( strpos( $param2, '.' ) !== false || strpos( $param2, $wpdb->prefix ) !== false ? $param2 : $wpdb->prepare( is_numeric( $param2 ) ? '%d' : '%s', $param2 ) ) );
 


### PR DESCRIPTION
## Proposed changes

Removed an unused preg_replace() call from the where method in the query builder. The removed line was causing a PHP deprecation warning in the log, as passing null to the preg_replace() function is deprecated.

https://jira.newfold.com/browse/PRESS0-1965

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

<!-- - [] I have read the [CONTRIBUTING](https://github.com/wp-forge/.github/blob/master/.github/CONTRIBUTING.md) doc -->
- [] Linting and tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
